### PR TITLE
hover_twiddle_tuner_node never updates ki as it is commented out

### DIFF
--- a/quad_controller/scripts/hover_twiddle_tuner_node
+++ b/quad_controller/scripts/hover_twiddle_tuner_node
@@ -119,7 +119,7 @@ def algorithm(pid_params):
     # Make the movement happen, stopping when some criteria has been met
     dyn_reconf_client.update_configuration({'target': 20.0,
                                             'kp': pid_params[0],
-                                            # 'ki': pid_params[1],
+                                            'ki': pid_params[1],
                                             'kd': pid_params[2]})
     curr_test_run.reset()
     curr_test_run.start()

--- a/quad_controller/src/quad_controller/twiddle.py
+++ b/quad_controller/src/quad_controller/twiddle.py
@@ -18,6 +18,8 @@ class Twiddle():
         for i in range(len(self.params_)):
             #Update parameter and run algorithm
             self.params_[i] += self.dp_[i]
+            if self.params_[i] < 0:
+                self.params_[i] = 0
             err = self.algorithm_(self.params_)
 
             if err < self.best_err_:
@@ -27,6 +29,8 @@ class Twiddle():
             else:
                 #The error actually got worse, decrease the parameter
                 self.params_[i] -= 2 * self.dp_[i]
+                if self.params_[i] < 0:
+                    self.params_[i] = 0
                 err = self.algorithm_(self.params_)
 
                 if err < self.best_err_:
@@ -34,6 +38,8 @@ class Twiddle():
                     self.dp_[i] *= 1.1
                 else:
                     self.params_[i] += self.dp_[i]
+                    if self.params_[i] < 0:
+                        self.params_[i] = 0
                     self.dp_[i] *= 0.9
         self.iterations_ += 1
         return self.iterations_, self.params_, self.best_err_


### PR DESCRIPTION
The hover_twiddle_tuner_node claims to update kp, ki and kd params, but I noticed ki is never actually updated, even though the printout to screen claims it has. I noticed the problem is that the line that sets ki has been commented out. I discussed this with original author Brandon Kinman and he confirmed this was added for testing and should be fixed. So this pull request simply removes the comment and allows ki to be set correctly.